### PR TITLE
Control jvm thread on our side

### DIFF
--- a/firebase_analytics/src/firebase_analytics.cpp
+++ b/firebase_analytics/src/firebase_analytics.cpp
@@ -409,7 +409,7 @@ static void LuaInit(lua_State* L) {
 
 	lua_pop(L, 1); // pop "firebase" global table
 }
-
+#undef THREAD_ATTACHER()
 #endif
 
 dmExtension::Result AppInitializeFirebaseAnalyticsExtension(dmExtension::AppParams* params) {

--- a/firebase_analytics/src/firebase_analytics.cpp
+++ b/firebase_analytics/src/firebase_analytics.cpp
@@ -6,6 +6,8 @@
 
 #if defined(DM_PLATFORM_ANDROID) || defined(DM_PLATFORM_IOS)
 
+#include <dmsdk/dlib/android.h>
+
 #include "firebase/app.h"
 #include "firebase/analytics.h"
 #include "firebase/analytics/event_names.h"
@@ -27,8 +29,10 @@ void FirebaseAnalytics_Safe_LogEvent(lua_State*, const char* name, const firebas
 {
 	LogEvent(name, params, number_of_parameters);
 }
+#define THREAD_ATTACHER() dmAndroid::ThreadAttacher threadAttacher;
+#else
+#define THREAD_ATTACHER()
 #endif
-
 
 static int FirebaseAnalytics_Init(lua_State* L) {
 	DM_LUA_STACK_CHECK(L, 0);
@@ -93,6 +97,7 @@ static int FirebaseAnalytics_Analytics_Log(lua_State* L) {
 		return 0;
 	}
 	const char* name = luaL_checkstring(L, 1);
+	THREAD_ATTACHER();
 	LogEvent(name);
 	return 0;
 }
@@ -107,6 +112,7 @@ static int FirebaseAnalytics_Analytics_LogString(lua_State* L) {
 	const char* name = luaL_checkstring(L, 1);
 	const char* parameter_name = luaL_checkstring(L, 2);
 	const char* parameter_value = luaL_checkstring(L, 3);
+	THREAD_ATTACHER();
 	LogEvent(name, parameter_name, parameter_value);
 	return 0;
 }
@@ -121,6 +127,7 @@ static int FirebaseAnalytics_Analytics_LogInt(lua_State* L) {
 	const char* name = luaL_checkstring(L, 1);
 	const char* parameter_name = luaL_checkstring(L, 2);
 	const int parameter_value = luaL_checkint(L, 3);
+	THREAD_ATTACHER();
 	LogEvent(name, parameter_name, parameter_value);
 	return 0;
 }
@@ -135,6 +142,7 @@ static int FirebaseAnalytics_Analytics_LogNumber(lua_State* L) {
 	const char* name = luaL_checkstring(L, 1);
 	const char* parameter_name = luaL_checkstring(L, 2);
 	const lua_Number parameter_value = luaL_checknumber(L, 3);
+	THREAD_ATTACHER();
 	LogEvent(name, parameter_name, parameter_value);
 	return 0;
 }
@@ -189,7 +197,7 @@ static int FirebaseAnalytics_Analytics_LogTable(lua_State* L) {
 		lua_pop(L, 1);
 		++size;
 	}
-
+	THREAD_ATTACHER();
 	FirebaseAnalytics_Safe_LogEvent(L, name, params, size);
 
 	lua_pop(L, 1);
@@ -203,6 +211,7 @@ static int FirebaseAnalytics_Analytics_Reset(lua_State* L) {
 		dmLogWarning("Firebase Analytics has not been initialized! Make sure to call firebase.analytics.init().");
 		return 0;
 	}
+	THREAD_ATTACHER();
 	ResetAnalyticsData();
 	return 0;
 }
@@ -215,6 +224,7 @@ static int FirebaseAnalytics_Analytics_SetEnabled(lua_State* L) {
 		return 0;
 	}
 	int enabled = lua_toboolean(L, 1);
+	THREAD_ATTACHER();
 	SetAnalyticsCollectionEnabled((bool)enabled);
 	return 0;
 }
@@ -233,6 +243,7 @@ static int FirebaseAnalytics_Analytics_SetUserProperty(lua_State* L) {
 	}
 	const char* name = luaL_checkstring(L, 1);
 	const char* property = luaL_checkstring(L, 2);
+	THREAD_ATTACHER();
 	SetUserProperty(name, property);
 	return 0;
 }
@@ -245,6 +256,7 @@ static int FirebaseAnalytics_Analytics_SetUserId(lua_State* L) {
 		return 0;
 	}
 	const char* user_id = luaL_checkstring(L, 1);
+	THREAD_ATTACHER();
 	SetUserId(user_id);
 	return 0;
 }


### PR DESCRIPTION
Now we have the following problem:
Firebase attach thread and detach only when the main thread shut down (if shutdown thread without detach it will crash the app). Firebase [does it safe](https://github.com/firebase/firebase-cpp-sdk/blob/6872ba47417796c8c24c6eab435534ad34b7a843/app/src/util_android.cc#L1889-L1892) - it attaches thread before detaching to avoid situation of attempt to detach thread which isn't attached.

It looks ok: just attach thread when you need it and don't detach - because you don't know who needs it except you.

But we use a bit different pattern for that. Our ThreadAttacher checks if thread attached or not, if it's not attached - then this particular attacher is "owner" and have to detach thread ([see code](https://github.com/defold/defold/blob/e9f674dde1f745147633d726b98d860a8ac750cf/engine/dlib/src/dlib/android.cpp#L31-L35) `m_IsAttached ` flag)

That means that even if we have create 10 ThreadAttacher instances only one instance will detach thread - the instance who attached the thread "the owner". But in case when the thread was attached by another code our ThreadAttacher will never be the owner and will never detach the thread.
That's why we have this leak.

My fix just keep management of the thread on our side using ThreadAttacher. If our ThreadAttacher attached thread - then it will detach.
But what about multiple call of the `AttachCurrentThread()`?

According to the [documentation](https://developer.android.com/training/articles/perf-jni#threads):
>Attaching a natively-created thread causes a java.lang.Thread object to be constructed and added to the “main” ThreadGroup, making it visible to the debugger. Calling AttachCurrentThread on an already-attached thread is a no-op.

I wasn't sure if `no-op` in this case means `does nothing` or `costs nothing`. I checked [Android source code](https://android.googlesource.com/platform/dalvik.git/+/android-4.2.2_r1/vm/Jni.cpp#2781) where I found that environment pointer still returned and it is `JNI_OK ` operation. So `no-op` means costs nothing (does nothing as well, but returning of the pointer is kinda operation).