### PR TITLE
Update Firebase Analytics SDKs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,8 @@ Find the version you want for both extensions, copy the URLs to the ZIP archives
 
 ![](add-dependency.png)
 
+Firebase Android SDK 34.x requires Android API level 23 or newer. Firebase Apple SDK 12.x requires iOS 15.0 or newer.
+
 
 ## Setup
 Follow the [main setup guide for integration of Firebase in Defold](https://www.defold.com/extension-firebase).

--- a/firebase_analytics/manifests/android/build.gradle
+++ b/firebase_analytics/manifests/android/build.gradle
@@ -3,6 +3,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-analytics:21.5.1'
-    implementation 'com.google.android.gms:play-services-base:18.2.0'
+    implementation platform('com.google.firebase:firebase-bom:34.16.0')
+    implementation 'com.google.firebase:firebase-analytics'
+    implementation 'com.google.android.gms:play-services-base:18.10.0'
 }

--- a/firebase_analytics/manifests/ios/Podfile
+++ b/firebase_analytics/manifests/ios/Podfile
@@ -1,3 +1,3 @@
-platform :ios '13.0'
+platform :ios, '15.0'
 
-pod 'FirebaseAnalytics', '11.15.0'
+pod 'FirebaseAnalytics', '12.16.0'

--- a/game.project
+++ b/game.project
@@ -28,6 +28,7 @@ infoplist = /builtins/manifests/ios/Info.plist
 
 [android]
 package = com.defold.firebase
+minimum_sdk_version = 23
 
 [osx]
 bundle_identifier = com.defold.firebase


### PR DESCRIPTION
## Summary

- update the Android Firebase BoM to 34.16.0, which resolves Firebase Analytics 23.2.0
- update Google Play services Base to 18.10.0
- update the Apple Firebase Analytics pod to 12.16.0
- raise the documented and configured minimums to Android API 23 and iOS 15
- document the new platform requirements

## Why

This keeps the extension aligned with the current Firebase Android and Apple SDK releases and their supported platform floors. The release notes do not require a native-source migration for the Java and Objective-C Analytics calls used by the extension, so the public Lua/native API remains unchanged.

Projects consuming this version must support Android API 23 or newer and iOS 15 or newer.

## Validation

Validated the example project with `/Users/agulev/Downloads/bob.jar` (Bob 1.13.1) together with the updated local Firebase core extension:

- Android build: passed using the production Defold Extender
- iOS build: passed using the official staging Defold Extender

The staging service was used for Apple validation because the production Apple worker failed before source compilation with an infrastructure-side missing Mustache `env` value. The same extension sources passed on staging.